### PR TITLE
repo: use LATEST for K9 mail

### DIFF
--- a/repo/packages.txt
+++ b/repo/packages.txt
@@ -70,8 +70,9 @@ Lawnchair_latest.apk|https://leech.binbash.rocks:8008/misc|app|Lawnchair-latest.
 
 # K9-Mail
 # latest version has no IMAP-idle / push
-# Earlier version 5.600 *with* IMAP-idle / push is available in F-Droid
-com.fsck.k9_27034.apk|FDROIDREPO|app|K9-Mail-latest.apk;PRESIGNED|true
+# Earlier version 5.600 *with* IMAP-idle / push is available in F-Droid 
+# (if the F-Droid Archive repo is enabled)
+com.fsck.k9_LATEST.apk|FDROIDREPO|app|K9-Mail-latest.apk;PRESIGNED|true
 
 # Fennec Browser
 org.mozilla.fennec_fdroid_LATEST.apk|FDROIDREPO|app|Fennec.apk;PRESIGNED|true


### PR DESCRIPTION
Use the `LATEST` keyword, instead of naming a version (that is no longer available)

K-9 have recently released the new stable version 5.8nn to replace 5.6nn. The old 5.7nn is now no longer available from F-Droid