### PR TITLE
Remove broken Lawnchair-latest target

### DIFF
--- a/repo/packages.txt
+++ b/repo/packages.txt
@@ -68,10 +68,6 @@ Omega.v0.8.0.Build.168.apk|https://github.com/otakuhqz/Omega/releases/download/v
 # taken from PlayStore via AuroraStore:
 Lawnchair_202589.apk|https://www.dropbox.com/s/qi551e1y2ubd1zd|app|Lawnchair-stable.apk;PRESIGNED|false
 
-# Lawnchair - latest
-# taken directly from the official Lawnchair TG group (https://t.me/lawnchairci)
-Lawnchair_latest.apk|https://leech.binbash.rocks:8008/misc|app|Lawnchair-latest.apk;PRESIGNED|false
-
 # OpenLauncher
 com.benny.openlauncher_LATEST.apk|FDROIDREPO|app|OpenLauncher.apk;PRESIGNED|true
 


### PR DESCRIPTION
Fixes https://github.com/sfX-android/android_vendor_extendrom/issues/28

An alternative approach would be to fix the Lawncair-latest target, but I've no idea how to do that