### PR TITLE
system_root_image is not guaranteed to be present

### DIFF
--- a/config/magisk/patches/0001-build_make_tools_releasetools_common.patch
+++ b/config/magisk/patches/0001-build_make_tools_releasetools_common.patch
@@ -11,7 +11,7 @@ index 0785c746eb..b83a28a4dd 100644
 +  # EXTENDROM: Magisk patcher
 +  if partition_name == "boot":
 +    mpatcher = [ 'vendor/extendrom/config/magisk/patch.sh', img.name ]
-+    RunAndCheckOutput(mpatcher, verbose=True, env={'system_root_image': info_dict["system_root_image"]})
++    RunAndCheckOutput(mpatcher, verbose=True, env={'system_root_image': info_dict.get("system_root_image", "false")})
 +
    # AVB: if enabled, calculate and add hash to boot.img or recovery.img.
    if info_dict.get("avb_enable") == "true":


### PR DESCRIPTION
This will result in a KeyError on some devices. Using a .get with default false (as is done elsewhere in the script) works around this issue.