### PR TITLE
Update file.te.sepolicy

### DIFF
--- a/config/boot_debug/file.te.sepolicy
+++ b/config/boot_debug/file.te.sepolicy
@@ -4,4 +4,4 @@
 ##################################################################
 
 # boot_debug
-type boot_log_file, boot_log_type, file_type;
+type boot_log_file, boot_log_type, file_type, data_file_type;


### PR DESCRIPTION
addresses the build error: "The following types on /data/ must be associated with the "data_file_type" attribute: boot_log_file"  when compiling LineageOS 17.1 (A10) with boot_debug enabled.